### PR TITLE
Potential fix for code scanning alert no. 37: URL redirection from remote source

### DIFF
--- a/src/routes/pages.py
+++ b/src/routes/pages.py
@@ -8,6 +8,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 import markdown
 from ..utils.link_processor import process_internal_links
+from urllib.parse import quote
 from ..utils.sanitizer import sanitize_html
 from ..services.page_service import PageService
 from ..services.branch_service import BranchService
@@ -324,7 +325,9 @@ async def delete_branch(request: Request, title: str, branch: str = Form("main")
             if not is_valid_title(title) or not is_safe_branch_parameter(branch):
                 logger.warning(f"Attempted redirect with invalid title '{title}' or branch '{branch}'")
                 return RedirectResponse(url="/", status_code=303)
-            return RedirectResponse(url=f"/page/{title}?branch={branch}", status_code=303)
+            safe_title = quote(title, safe="")
+            safe_branch = quote(branch, safe="")
+            return RedirectResponse(url=f"/page/{safe_title}?branch={safe_branch}", status_code=303)
         else:
             logger.warning(f"Branch not found for deletion: {branch} from page {title}")
             return {"error": "Branch not found"}


### PR DESCRIPTION
Potential fix for [https://github.com/superintendent2521/wikiware/security/code-scanning/37](https://github.com/superintendent2521/wikiware/security/code-scanning/37)

To fix the issue, ensure that the values interpolated into the redirect URL are strictly validated or sanitized, and that the resulting URL can't be interpreted as an absolute, network-path, or otherwise malicious URL by a browser. The recommended approach is:

- Continue to use and possibly reinforce `is_valid_title` and `is_safe_branch_parameter`, but also ensure their output *cannot* be used by browsers to craft unexpected paths.
- When redirecting, use a path-only redirect that guarantees the output URL is never a full URL or a network-path URL. Avoid accepting or generating any slashes, backslashes, protocol separators (`:`), or sequences that can manipulate URL path parsing in browsers.
- Alternatively, use a allowlist of destinations (not easy here) or strictly encode the redirect parameters.

**Best fix for the example:**  
- Strictly encode `title` and `branch` using `urllib.parse.quote` so that even if the input is malicious, the output cannot cause a redirect break-out (for example, `/?branch=//evil.com`).  
- Re-validate (and possibly reinforce) the semantic meaning of `is_valid_title` and `is_safe_branch_parameter`.
- Add an import for `urllib.parse.quote`.

Apply changes only in `src/routes/pages.py` in the region of the affected code (line 327):  
- Import `quote` from `urllib.parse` at the top.
- Wrap both `title` and `branch` in `quote` before building the redirect URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
